### PR TITLE
Made it possible to set the options for the request

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -2,8 +2,19 @@ var request = require("request");
 
 module.exports = getJSON;
 
-function getJSON (url, callback) {
-  request({ url: url, json: true }, function (error, response, body) {
+function getJSON (url, options, callback) {
+  if (!callback) {
+    callback = options;
+    options  = null;
+  }
+
+  var defaultOptions = { url: url, json: true };
+
+  if (options) {
+    defaultOptions = Object.assign(defaultOptions, options);
+  }
+
+  request(defaultOptions, function (error, response, body) {
     if(error) return callback(error);
 
     if(response.statusCode != 200) return;

--- a/test.js
+++ b/test.js
@@ -9,3 +9,13 @@ test('get last songs from radio paradise api', function (t) {
     t.equal(body.result.length, 4);
   });
 });
+
+test('get repositories from GitHub', function (t) {
+  json('https://api.github.com/repositories', { 'headers': { 'User-Agent': 'A user agent' } }, function (error, body) {
+    t.plan(4);
+    t.error(error);
+    t.ok(body[0]);
+    t.ok(body[0].name);
+    t.equal(body.length, 100);
+  });
+});


### PR DESCRIPTION
I need this since I was trying to get my GitHub user data (https://api.github.com/users/blaues0cke) and `getJSON` failed without an error. Figured out that GitHub responds with

```
'Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.\n' } Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.` so I had to make it possible to pass the options to set a `User-Agent`
```

Example code:

```
var apiUrl = 'https://api.github.com/users/blaues0cke';

getJSON(apiUrl, { 'headers': { 'User-Agent': 'request' } }, function(error, response) {

});
```

(Dont know if this is compatible with the api from `jsonp`.
